### PR TITLE
fix: T.E.O.Sのリンクを修正しました

### DIFF
--- a/canal-testing/canal-overview.md
+++ b/canal-testing/canal-overview.md
@@ -22,7 +22,7 @@
 
 ![canal全体構成](img/canal-overview.png)
 
-canalは、[T.E.O.S](https://www.tis.jp/service_solution/cloud/)というクラウドサービス上で稼働しています。
+canalは、[T.E.O.S](https://www.einswave.jp/service/cloud/teos/)というクラウドサービス上で稼働しています。
 
 ユーザーに対するインターフェースをScoold、データの保存・検索などにはParaというオープンソースのソフトウェアを採用しており、これらがcanalを構成する主要な要素となっています。
 

--- a/canal-testing/canal-overview.md
+++ b/canal-testing/canal-overview.md
@@ -22,7 +22,7 @@
 
 ![canal全体構成](img/canal-overview.png)
 
-canalは、[T.E.O.S](https://www.einswave.jp/service/cloud/teos/)というクラウドサービス上で稼働しています。
+canalは、[T.E.O.S](https://www.einswave.jp/service/cloud/)というクラウドサービス上で稼働しています。
 
 ユーザーに対するインターフェースをScoold、データの保存・検索などにはParaというオープンソースのソフトウェアを採用しており、これらがcanalを構成する主要な要素となっています。
 


### PR DESCRIPTION
## 事象

T.E.O.Sのリンク先が`Forbidden` と表示されており、参照できませんでした。

### 画面キャプチャ

  ![image](https://user-images.githubusercontent.com/25531890/79048053-67936a00-7c55-11ea-8595-d4babf32206f.png)


## 対応

「TIS TEOS」 でGoogle検索して見つけたリンクに変更しました。
※ リンク変更先が正しい保証ができておらず、ご確認をお願いいたします。